### PR TITLE
Fix compatibility issues

### DIFF
--- a/sphinxcontrib/yuml.py
+++ b/sphinxcontrib/yuml.py
@@ -19,6 +19,27 @@ from docutils.parsers.rst import directives
 import docutils.parsers.rst.directives.images
 from sphinx.errors import SphinxError
 from sphinx.util import ensuredir, relative_uri
+
+try:
+    from sphinx.util import logging
+    logger = logging.getLogger(__name__)
+    def log_warn(app, message):
+        logger.warning(message)
+    def log_info(app, message):
+        logger.info(message)
+    def debug(app, message):
+        logger.debug(message)
+except ImportError:
+    def log_warn(app, message):
+        app.builder.warn(message)
+    def log_info(app, message):
+        app.builder.info(message)
+    def debug(app, message):
+        try:
+            app.debug(message)
+        except Exception:
+            log_info(app, '[Debug] ' + message)
+
 try:
     from hashlib import sha1 as sha
 except ImportError:
@@ -95,7 +116,7 @@ class YumlDirective(directives.images.Image):
         return [image_node]
         
 def render_yuml_images(app, doctree):
-    app.builder.info('Rendering Yuml')
+    log_info(app, 'Rendering Yuml')
     for img in doctree.traverse(nodes.image):
         if not hasattr(img, 'yuml'):
             continue
@@ -134,7 +155,7 @@ def render_yuml(app, uri, text, options):
     else:
         # Non-HTML
         if app.builder.format != 'latex':
-            app.builder.warn('yuml: the builder format %s is not supported.' % app.builder.format)
+            log_warn(app, 'yuml: the builder format %s is not supported.' % app.builder.format)
         relfn = fname
         outfn = path.join(app.builder.outdir, fname)
 
@@ -168,13 +189,6 @@ def render_yuml(app, uri, text, options):
         raise YumlError(str(e))
 
     return relfn
-
-def debug(app, msg):
-    try:
-        app.debug(msg)
-    except Exception:
-        app.builder.info('[Debug] ' + msg)
-
 
 def setup(app):
     app.add_config_value('yuml_server_url', 'http://yuml.me/diagram/', 'html')

--- a/sphinxcontrib/yuml.py
+++ b/sphinxcontrib/yuml.py
@@ -49,13 +49,13 @@ class YumlDirective(directives.images.Image):
            :type: class, activity or usecase
            :scale: positive integer value
            :direction: LR, TD or RL
-           :style: boring, plain, scruffy
+           :style: boring, nofunky, plain, scruffy
 
            [Customer]->[Billing Address]
     """
     type_values = ('class', 'activity', 'usecase')
     direction_values = ('LR', 'RL', 'TD')
-    style_values=('boring', 'plain', 'scruffy')
+    style_values=('boring', 'nofunky', 'plain', 'scruffy')
 
     def type_choice(argument):
         return directives.choice(argument, YumlDirective.type_values)
@@ -81,6 +81,8 @@ class YumlDirective(directives.images.Image):
 
     def run(self):
         yuml_options = dict([(k,v) for k,v in self.options.items() if k in self.own_option_spec])
+        if yuml_options.get('style') == 'boring':
+            yuml_options['style'] = 'nofunky'
         self.arguments = ['']
 
         (image_node,) = directives.images.Image.run(self)

--- a/sphinxcontrib/yuml.py
+++ b/sphinxcontrib/yuml.py
@@ -15,6 +15,7 @@ import re
 from os import path
 from docutils import nodes
 from docutils.parsers.rst import directives
+import docutils.parsers.rst.directives.images
 from sphinx.errors import SphinxError
 from sphinx.util import ensuredir, relative_uri
 try:
@@ -174,4 +175,3 @@ def setup(app):
     app.add_config_value('yuml_options', DEFAULT_OPTIONS, '')
     app.connect('doctree-read', render_yuml_images)
     app.add_directive('yuml', YumlDirective)
-    

--- a/sphinxcontrib/yuml.py
+++ b/sphinxcontrib/yuml.py
@@ -9,6 +9,7 @@
     :license: GPLv3
 """
 
+import sys
 import posixpath
 import urllib2, urllib
 import re
@@ -105,8 +106,10 @@ def render_yuml_images(app, doctree):
         try:
             img['uri'] = render_yuml(app, uri, text, options)
             img['candidates']={'?':''}
-        except YumlError, exc:
-            app.builder.warn('yuml error: ' + str(exc))
+        except YumlError:
+            (_t, exc, _tb) = sys.exc_info()
+            del(_tb)
+            log_warn(app, 'yuml error: ' + str(exc))
             img.replace_self(nodes.literal_block(text, text))
             continue
 
@@ -159,7 +162,9 @@ def render_yuml(app, uri, text, options):
         out = open(outfn, 'wb')
         out.write(rep)
         out.close()
-    except Exception as e:
+    except Exception:
+        (_t, e, _tb) = sys.exc_info()
+        del(_tb)
         raise YumlError(str(e))
 
     return relfn
@@ -167,7 +172,7 @@ def render_yuml(app, uri, text, options):
 def debug(app, msg):
     try:
         app.debug(msg)
-    except Exception as e:
+    except Exception:
         app.builder.info('[Debug] ' + msg)
 
 


### PR DESCRIPTION
- If docutils.parsers.rst.directives.images is not imported, directives.images is not defined
- style `boring` is now called `nofunky`
- exception syntax is different for various python versions
- Sphinx has deprecated app.info, app.warn, app.debug in v1.6